### PR TITLE
Contribute link points to non-existing file

### DIFF
--- a/en/drupal_console_faq/commands-not-listed.md
+++ b/en/drupal_console_faq/commands-not-listed.md
@@ -1,4 +1,4 @@
 # Commands not listed
 This document is a work-in-progress. At any time, it is possible that the Drupal Console project is ahead of the documentation. While we endeavor to keep this book up-to-date, it is always possible that some commands have been created for the Drupal Console, but are not yet described in this document. For a full list of supported commands, use the **list** command, e.g. `$ drupal list`
 
-If you see a command that is not yet described here, you are also welcome to [contribute to this documentation](../contribute_to_drupal_console/contribute-to-the-drupal-console-book.md "Contribute to the Drupal Console documentation"), using the **--help** output for the command as a simple starting point.
+If you see a command that is not yet described here, you are also welcome to [contribute to this documentation](../contributing/contributing-to-the-book.md "Contribute to the Drupal Console documentation"), using the **--help** output for the command as a simple starting point.


### PR DESCRIPTION
The link pointed to a non-existing file.
It now points the the right file, which is still in Spanish. 
A better solution might be to points to the [github repository](https://github.com/hechoendrupal/drupal-console-book) in the meanwhile.