### PR TITLE
Use version of gitbook compatible with current node/npm releases.

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,5 +1,5 @@
 {
-  "gitbook": "2.6.7",
+  "gitbook": "3.2.2",
   "plugins": [
     "edit-link",
     "github"


### PR DESCRIPTION
The latest version of book.json requests a Gitbook 2.6.7 install.

However, Gitbook versions 2.6.x have been broken since node v7.x and the current versions of node are in the v8.x series. Using the current latest stable version of gitbook (3.2.2) for the book allows gitbook to build/serve it, while 2.6.7 no longer does.