### PR TITLE
Global key missing from config command

### DIFF
--- a/en/getting/launcher.md
+++ b/en/getting/launcher.md
@@ -23,8 +23,8 @@ drupal
 ## Installing the Launcher using Composer 
 Set Composer global `minimum-stability` and `prefer-stable` configurations.
 ```
-composer config minimum-stability dev
-composer config prefer-stable true
+composer global config minimum-stability dev
+composer global config prefer-stable true
 ```
 ```
 composer global require drupal/console-launcher:~1.0


### PR DESCRIPTION
The `global` key must be added to set global configuration on composer.