### PR TITLE
Module path doesn't work if it is preceded with /

### DIFF
--- a/en/commands/generate-module.md
+++ b/en/commands/generate-module.md
@@ -29,7 +29,7 @@ Option | Details
 drupal generate:module  \
   --module="modulename"  \
   --machine-name="modulename"  \
-  --module-path="/modules/custom"  \
+  --module-path="modules/custom"  \
   --description="My Awesome Module"  \
   --core="8.x"  \
   --package="Custom"  \


### PR DESCRIPTION
When following the instructions the module generation failed at the --module-path value. So I ran the command without it so Drupal Console would prompt me. The default suggested value in the interactive shell is "modules/custom". I took this suggestion and everything worked fine.

Due to this I wanted to update the documentation.